### PR TITLE
Improve signal lookup query performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: mix deps.audit
       - name: Run security-focused static analysis (ignoring HTTPS until automatic deployment)
         run: mix sobelow -i Config.HTTPS
-      - name: Run dialyzer
-        run: mix dialyzer --format github
       - name: Run Credo
         run: mix credo -i todo
+      - name: Run dialyzer
+        run: mix dialyzer --format github

--- a/lib/nautic_net/application.ex
+++ b/lib/nautic_net/application.ex
@@ -25,7 +25,8 @@ defmodule NauticNet.Application do
       # Start the Endpoint (http/https)
       NauticNetWeb.Endpoint,
       # Start the protobuf UDP listener
-      {NauticNet.Ingest.UDPServer, port: Application.fetch_env!(:nautic_net, :udp_port)}
+      {NauticNet.Ingest.UDPServer, port: Application.fetch_env!(:nautic_net, :udp_port)},
+      {NauticNet.MaterializedViewRefresher, view: "active_channels", interval: :timer.seconds(60)}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/nautic_net/data/active_channel.ex
+++ b/lib/nautic_net/data/active_channel.ex
@@ -1,0 +1,16 @@
+defmodule NauticNet.Data.ActiveChannel do
+  @moduledoc """
+  Materialized view to determine which signal channels were active on any UTC date.
+
+  It must be manually refreshed. See `NauticNet.MaterializedViewRefresher`.
+  """
+  use NauticNet.Schema
+
+  schema "active_channels" do
+    belongs_to :boat, NauticNet.Racing.Boat
+    belongs_to :sensor, NauticNet.Data.Sensor
+
+    field :utc_date, :date
+    field :type, Ecto.Enum, values: Enum.map(NauticNet.Data.Sample.types(), & &1.type)
+  end
+end

--- a/lib/nautic_net/local_date.ex
+++ b/lib/nautic_net/local_date.ex
@@ -4,4 +4,32 @@ defmodule NauticNet.LocalDate do
   """
   @enforce_keys [:date, :timezone]
   defstruct [:date, :timezone]
+
+  @doc """
+  Returns a list of UTC Dates that overlap with the local date.
+  """
+  def utc_dates(%__MODULE__{} = local_date) do
+    {utc_start, utc_end} = utc_interval(local_date)
+
+    Enum.uniq([Timex.to_date(utc_start), Timex.to_date(utc_end)])
+  end
+
+  @doc """
+  Return a tuple of UTC DateTimes at the beginning and end of the local date.
+  """
+  def utc_interval(%__MODULE__{} = local_date) do
+    {local_start, local_end} = local_interval(local_date)
+
+    {Timex.to_datetime(local_start, "Etc/UTC"), Timex.to_datetime(local_end, "Etc/UTC")}
+  end
+
+  @doc """
+  Returns a tuple of local DateTimes at the beginning and end of the date.
+  """
+  def local_interval(%__MODULE__{} = local_date) do
+    {
+      local_date.date |> Timex.to_datetime(local_date.timezone) |> Timex.beginning_of_day(),
+      local_date.date |> Timex.to_datetime(local_date.timezone) |> Timex.end_of_day()
+    }
+  end
 end

--- a/lib/nautic_net/local_date.ex
+++ b/lib/nautic_net/local_date.ex
@@ -1,0 +1,7 @@
+defmodule NauticNet.LocalDate do
+  @moduledoc """
+  Represents a Date in a specific timezone.
+  """
+  @enforce_keys [:date, :timezone]
+  defstruct [:date, :timezone]
+end

--- a/lib/nautic_net/materialized_view_refresher.ex
+++ b/lib/nautic_net/materialized_view_refresher.ex
@@ -1,0 +1,36 @@
+defmodule NauticNet.MaterializedViewRefresher do
+  @moduledoc """
+  GenServer to refresh a materialized view at a scheduled interval.
+
+  ## Options
+
+    - `:view` (required) - the name of the materialized view
+    - `:interval` (required) - the refresh interval, in milliseconds
+
+  """
+  use GenServer
+
+  alias NauticNet.Repo
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    view = opts[:view] || raise "the :view option is required"
+    interval = opts[:interval] || raise "the :interval option is required"
+
+    send(self(), :refresh)
+    {:ok, %{view: view, interval: interval}}
+  end
+
+  @impl GenServer
+  def handle_info(:refresh, state) do
+    Ecto.Adapters.SQL.query(Repo, "REFRESH MATERIALIZED VIEW #{state.view};")
+
+    Process.send_after(self(), :refresh, state.interval)
+
+    {:noreply, state}
+  end
+end

--- a/lib/nautic_net/playback.ex
+++ b/lib/nautic_net/playback.ex
@@ -18,7 +18,7 @@ defmodule NauticNet.Playback do
     sensors_by_id = Sensor |> Repo.all() |> Map.new(&{&1.id, &1})
 
     ActiveChannel
-    |> where([as], as.utc_date in ^utc_dates(local_date))
+    |> where([as], as.utc_date in ^LocalDate.utc_dates(local_date))
     |> select([s], [:boat_id, :sensor_id, :type])
     |> distinct(true)
     |> Repo.all()
@@ -30,33 +30,13 @@ defmodule NauticNet.Playback do
     end)
   end
 
-  # The active_signals view contains UTC dates, so we need to determine which UTC dates
-  # overlap with the specified Date in its desired timezone
-  defp utc_dates(%LocalDate{} = local_date) do
-    start_utc_date =
-      local_date.date
-      |> Timex.to_datetime(local_date.timezone)
-      |> Timex.beginning_of_day()
-      |> Timex.to_datetime("Etc/UTC")
-      |> Timex.to_date()
-
-    end_utc_date =
-      local_date.date
-      |> Timex.to_datetime(local_date.timezone)
-      |> Timex.end_of_day()
-      |> Timex.to_datetime("Etc/UTC")
-      |> Timex.to_date()
-
-    [start_utc_date, end_utc_date]
-  end
-
   @doc """
   Returns a list of Boat structs that were active on a given day.
   """
   def list_active_boats(%LocalDate{} = local_date) do
     boat_ids =
       Sample
-      |> where_date(local_date)
+      |> where_local_date(local_date)
       |> select([s], s.boat_id)
       |> distinct(true)
       |> Repo.all()
@@ -80,7 +60,7 @@ defmodule NauticNet.Playback do
     positions =
       Sample
       |> where_channel(channel)
-      |> where_date(local_date_or_interval, local_timezone)
+      |> where_local_date(local_date_or_interval, local_timezone)
       |> order_by([s], s.time)
       |> select([s], {s.time, s.position})
       |> Repo.all()
@@ -223,30 +203,17 @@ defmodule NauticNet.Playback do
   #   end)
   # end
 
-  defp where_date(query, %LocalDate{} = local_date) do
-    where_date(query, local_date.date, local_date.timezone)
+  defp where_local_date(query, %LocalDate{} = local_date) do
+    where_utc_date(query, local_date)
   end
 
-  # Convert the date to a pair of DateTimes that represent the start and end of the day in the desired
-  # timezone, but then convert to UTC for easy interpolation into the database
-  defp where_date(query, {start_utc, end_utc}, "Etc/UTC") do
+  defp where_local_date(query, %Date{} = date, timezone) do
+    where_utc_date(query, %LocalDate{date: date, timezone: timezone})
+  end
+
+  defp where_utc_date(query, %LocalDate{} = local_date) do
+    {start_utc, end_utc} = LocalDate.utc_interval(local_date)
     where(query, [s], s.time >= ^start_utc and s.time <= ^end_utc)
-  end
-
-  defp where_date(query, %Date{} = local_date, local_timezone) do
-    start_utc =
-      local_date
-      |> Timex.to_datetime(local_timezone)
-      |> Timex.beginning_of_day()
-      |> Timex.to_datetime("Etc/UTC")
-
-    end_utc =
-      local_date
-      |> Timex.to_datetime(local_timezone)
-      |> Timex.end_of_day()
-      |> Timex.to_datetime("Etc/UTC")
-
-    where_date(query, {start_utc, end_utc}, "Etc/UTC")
   end
 
   defp where_channel(sample_query, %Channel{} = channel) do
@@ -262,7 +229,7 @@ defmodule NauticNet.Playback do
   def get_sample_range_on(%LocalDate{} = local_date) do
     first_sample_at_utc =
       Sample
-      |> where_date(local_date)
+      |> where_local_date(local_date)
       |> order_by([s], asc: s.time)
       |> limit(1)
       |> select([s], s.time)
@@ -270,7 +237,7 @@ defmodule NauticNet.Playback do
 
     last_sample_at_utc =
       Sample
-      |> where_date(local_date)
+      |> where_local_date(local_date)
       |> order_by([s], desc: s.time)
       |> limit(1)
       |> select([s], s.time)
@@ -284,10 +251,7 @@ defmodule NauticNet.Playback do
       }
     else
       # Generate local start/end of day if there are no samples
-      {
-        local_date.date |> Timex.to_datetime(local_date.timezone) |> Timex.beginning_of_day(),
-        local_date.date |> Timex.to_datetime(local_date.timezone) |> Timex.end_of_day()
-      }
+      LocalDate.local_interval(local_date)
     end
   end
 end

--- a/lib/nautic_net/playback.ex
+++ b/lib/nautic_net/playback.ex
@@ -8,32 +8,17 @@ defmodule NauticNet.Playback do
   alias NauticNet.Data.ActiveChannel
   alias NauticNet.Data.Sample
   alias NauticNet.Data.Sensor
+  alias NauticNet.LocalDate
   alias NauticNet.Playback.Channel
   alias NauticNet.Racing.Boat
   alias NauticNet.Repo
 
-  def list_channels_on(%Date{} = date, timezone) do
+  def list_channels_on(%LocalDate{} = local_date) do
     boats_by_id = Boat |> Repo.all() |> Map.new(&{&1.id, &1})
     sensors_by_id = Sensor |> Repo.all() |> Map.new(&{&1.id, &1})
 
-    # The active_signals view contains UTC dates, so we need to determine which UTC dates
-    # overlap with the specified Date in its desired timezone
-    start_utc_date =
-      date
-      |> Timex.to_datetime(timezone)
-      |> Timex.beginning_of_day()
-      |> Timex.to_datetime("Etc/UTC")
-      |> Timex.to_date()
-
-    end_utc_date =
-      date
-      |> Timex.to_datetime(timezone)
-      |> Timex.end_of_day()
-      |> Timex.to_datetime("Etc/UTC")
-      |> Timex.to_date()
-
     ActiveChannel
-    |> where([as], as.utc_date in ^[start_utc_date, end_utc_date])
+    |> where([as], as.utc_date in ^utc_dates(local_date))
     |> select([s], [:boat_id, :sensor_id, :type])
     |> distinct(true)
     |> Repo.all()
@@ -45,13 +30,33 @@ defmodule NauticNet.Playback do
     end)
   end
 
+  # The active_signals view contains UTC dates, so we need to determine which UTC dates
+  # overlap with the specified Date in its desired timezone
+  defp utc_dates(%LocalDate{} = local_date) do
+    start_utc_date =
+      local_date.date
+      |> Timex.to_datetime(local_date.timezone)
+      |> Timex.beginning_of_day()
+      |> Timex.to_datetime("Etc/UTC")
+      |> Timex.to_date()
+
+    end_utc_date =
+      local_date.date
+      |> Timex.to_datetime(local_date.timezone)
+      |> Timex.end_of_day()
+      |> Timex.to_datetime("Etc/UTC")
+      |> Timex.to_date()
+
+    [start_utc_date, end_utc_date]
+  end
+
   @doc """
   Returns a list of Boat structs that were active on a given day.
   """
-  def list_active_boats(%Date{} = date, timezone) do
+  def list_active_boats(%LocalDate{} = local_date) do
     boat_ids =
       Sample
-      |> where_date(date, timezone)
+      |> where_date(local_date)
       |> select([s], s.boat_id)
       |> distinct(true)
       |> Repo.all()
@@ -62,16 +67,20 @@ defmodule NauticNet.Playback do
     |> Repo.all()
   end
 
+  def list_coordinates(%Channel{} = channel, %LocalDate{} = local_date) do
+    list_coordinates(channel, local_date.date, local_date.timezone)
+  end
+
   @doc """
   Returns a list of coordinate maps for display in MapLive.
 
   Keys: :time, :latitude, :longitude, :true_heading
   """
-  def list_coordinates(%Channel{} = channel, date_or_interval, timezone) do
+  def list_coordinates(%Channel{} = channel, local_date_or_interval, local_timezone) do
     positions =
       Sample
       |> where_channel(channel)
-      |> where_date(date_or_interval, timezone)
+      |> where_date(local_date_or_interval, local_timezone)
       |> order_by([s], s.time)
       |> select([s], {s.time, s.position})
       |> Repo.all()
@@ -214,22 +223,26 @@ defmodule NauticNet.Playback do
   #   end)
   # end
 
+  defp where_date(query, %LocalDate{} = local_date) do
+    where_date(query, local_date.date, local_date.timezone)
+  end
+
   # Convert the date to a pair of DateTimes that represent the start and end of the day in the desired
   # timezone, but then convert to UTC for easy interpolation into the database
   defp where_date(query, {start_utc, end_utc}, "Etc/UTC") do
     where(query, [s], s.time >= ^start_utc and s.time <= ^end_utc)
   end
 
-  defp where_date(query, %Date{} = date, timezone) do
+  defp where_date(query, %Date{} = local_date, local_timezone) do
     start_utc =
-      date
-      |> Timex.to_datetime(timezone)
+      local_date
+      |> Timex.to_datetime(local_timezone)
       |> Timex.beginning_of_day()
       |> Timex.to_datetime("Etc/UTC")
 
     end_utc =
-      date
-      |> Timex.to_datetime(timezone)
+      local_date
+      |> Timex.to_datetime(local_timezone)
       |> Timex.end_of_day()
       |> Timex.to_datetime("Etc/UTC")
 
@@ -246,10 +259,10 @@ defmodule NauticNet.Playback do
   @doc """
   Returns the range of DateTimes over which samples exist on a given date.
   """
-  def get_sample_range_on(%Date{} = date, timezone) do
+  def get_sample_range_on(%LocalDate{} = local_date) do
     first_sample_at_utc =
       Sample
-      |> where_date(date, timezone)
+      |> where_date(local_date)
       |> order_by([s], asc: s.time)
       |> limit(1)
       |> select([s], s.time)
@@ -257,7 +270,7 @@ defmodule NauticNet.Playback do
 
     last_sample_at_utc =
       Sample
-      |> where_date(date, timezone)
+      |> where_date(local_date)
       |> order_by([s], desc: s.time)
       |> limit(1)
       |> select([s], s.time)
@@ -266,14 +279,14 @@ defmodule NauticNet.Playback do
     if first_sample_at_utc && last_sample_at_utc do
       # Convert from UTC to local
       {
-        Timex.to_datetime(first_sample_at_utc, timezone),
-        Timex.to_datetime(last_sample_at_utc, timezone)
+        Timex.to_datetime(first_sample_at_utc, local_date.timezone),
+        Timex.to_datetime(last_sample_at_utc, local_date.timezone)
       }
     else
       # Generate local start/end of day if there are no samples
       {
-        date |> Timex.to_datetime(timezone) |> Timex.beginning_of_day(),
-        date |> Timex.to_datetime(timezone) |> Timex.end_of_day()
+        local_date.date |> Timex.to_datetime(local_date.timezone) |> Timex.beginning_of_day(),
+        local_date.date |> Timex.to_datetime(local_date.timezone) |> Timex.end_of_day()
       }
     end
   end

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -2,6 +2,7 @@ defmodule NauticNetWeb.MapLive do
   use NauticNetWeb, :live_view
 
   alias Phoenix.PubSub
+  alias NauticNet.LocalDate
   alias NauticNet.Playback
   alias NauticNet.Playback.Channel
   alias NauticNet.Playback.Signal
@@ -15,6 +16,8 @@ defmodule NauticNetWeb.MapLive do
     "min_lon" => -71.0473,
     "max_lon" => -70.8557
   }
+
+  @timezone "America/New_York"
 
   @signal_views [
     %{type: :true_heading, label: "True Heading", field: :angle, unit: :deg},
@@ -55,8 +58,7 @@ defmodule NauticNetWeb.MapLive do
 
       # Timeline
       |> assign(:inspect_at, DateTime.utc_now())
-      |> assign(:timezone, "America/New_York")
-      |> select_date(Timex.today("America/New_York"))
+      |> select_date(Timex.today(@timezone), @timezone)
 
     {:ok, socket}
   end
@@ -86,8 +88,8 @@ defmodule NauticNetWeb.MapLive do
   end
 
   def handle_event("update_range", %{"min" => min, "max" => max}, socket) do
-    range_start_at = parse_unix_datetime(min, socket.assigns.timezone)
-    range_end_at = parse_unix_datetime(max, socket.assigns.timezone)
+    range_start_at = parse_unix_datetime(min, socket.assigns.local_date.timezone)
+    range_end_at = parse_unix_datetime(max, socket.assigns.local_date.timezone)
 
     {:noreply,
      socket
@@ -120,7 +122,7 @@ defmodule NauticNetWeb.MapLive do
   def handle_event("select_date", %{"date" => date_param}, socket) do
     date = Date.from_iso8601!(date_param)
 
-    {:noreply, select_date(socket, date)}
+    {:noreply, select_date(socket, date, socket.assigns.local_date.timezone)}
   end
 
   def handle_event("select_boat", %{"boat_id" => boat_id}, socket) do
@@ -194,7 +196,7 @@ defmodule NauticNetWeb.MapLive do
   # PubSub message from NauticNet.Ingest
   # def handle_info({:new_samples, samples}, %{assigns: %{live?: true} = assigns} = socket) do
   #   # Only care about samples that are "today"
-  #   samples = Enum.filter(samples, fn s -> DateTime.to_date(s.time) == assigns.selected_date end)
+  #   samples = Enum.filter(samples, fn s -> DateTime.to_date(s.time) == assigns.local_date end)
 
   #   # Update the latest_sample for applicable signals
   #   signals =
@@ -245,8 +247,7 @@ defmodule NauticNetWeb.MapLive do
         coordinates =
           Playback.list_coordinates(
             signal.channel,
-            socket.assigns.selected_date,
-            socket.assigns.timezone
+            socket.assigns.local_date
           )
 
         boat_view = %{
@@ -325,7 +326,7 @@ defmodule NauticNetWeb.MapLive do
 
     new_inspect_at =
       if pos = params["position"] do
-        parse_unix_datetime(pos, assigns.timezone)
+        parse_unix_datetime(pos, assigns.local_date.timezone)
       else
         assigns.inspect_at
       end
@@ -417,21 +418,23 @@ defmodule NauticNetWeb.MapLive do
   # end
 
   # Set the date, boats, and data sources
-  defp select_date(%{assigns: assigns} = socket, date) do
+  defp select_date(socket, date, timezone) do
+    local_date = %LocalDate{date: date, timezone: timezone}
+
     signals =
-      date
-      |> Playback.list_channels_on(assigns.timezone)
+      local_date
+      |> Playback.list_channels_on()
       |> Enum.map(fn %Channel{boat: boat} = channel ->
         %Signal{channel: channel, color: boat_color(boat.id)}
       end)
 
     # Set up the range for the main slider
-    {first_sample_at, last_sample_at} = Playback.get_sample_range_on(date, assigns.timezone)
+    {first_sample_at, last_sample_at} = Playback.get_sample_range_on(local_date)
 
     first_position_signal = Enum.find(signals, &(&1.channel.type == :position))
 
     socket
-    |> assign(:selected_date, date)
+    |> assign(:local_date, local_date)
     |> unsubscribe_from_boats()
     |> assign(:signals, signals)
     |> subscribe_to_boats()
@@ -554,18 +557,18 @@ defmodule NauticNetWeb.MapLive do
     push_event(socket, "map_view", %{latitude: latitude, longitude: longitude})
   end
 
-  defp parse_unix_datetime(param, timezone) when is_binary(param) do
+  defp parse_unix_datetime(param, local_timezone) when is_binary(param) do
     param
     |> Float.parse()
     |> elem(0)
     |> trunc()
-    |> parse_unix_datetime(timezone)
+    |> parse_unix_datetime(local_timezone)
   end
 
-  defp parse_unix_datetime(param, timezone) when is_integer(param) do
+  defp parse_unix_datetime(param, local_timezone) when is_integer(param) do
     param
     |> DateTime.from_unix!()
-    |> Timex.to_datetime(timezone)
+    |> Timex.to_datetime(local_timezone)
   end
 
   defp boat_color(boat_id) do

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -264,9 +264,14 @@ defmodule NauticNetWeb.MapLive do
             end)
         }
 
-        {min_lat, max_lat} = coordinates |> Enum.map(& &1.latitude) |> Enum.min_max()
-        {min_lon, max_lon} = coordinates |> Enum.map(& &1.longitude) |> Enum.min_max()
-        center_coord = {(min_lat + max_lat) / 2, (min_lon + max_lon) / 2}
+        center_coord =
+          if coordinates == [] do
+            nil
+          else
+            {min_lat, max_lat} = coordinates |> Enum.map(& &1.latitude) |> Enum.min_max()
+            {min_lon, max_lon} = coordinates |> Enum.map(& &1.longitude) |> Enum.min_max()
+            {(min_lat + max_lat) / 2, (min_lon + max_lon) / 2}
+          end
 
         send(live_view_pid, {:push_boat_view, boat_view, center_coord})
 
@@ -289,7 +294,7 @@ defmodule NauticNetWeb.MapLive do
   end
 
   defp maybe_recenter_map(socket, center_coord) do
-    if socket.assigns.needs_centering? do
+    if socket.assigns.needs_centering? and center_coord != nil do
       socket
       |> set_map_view(center_coord)
       |> assign(:needs_centering?, false)

--- a/lib/nautic_net_web/live/map_live.html.heex
+++ b/lib/nautic_net_web/live/map_live.html.heex
@@ -7,7 +7,7 @@
         type="date"
         id="date"
         name="date"
-        value={@selected_date}
+        value={@local_date.date}
         errors={[]}
         disabled={@live?}
       />

--- a/priv/repo/migrations/20230721133659_create_active_channels.exs
+++ b/priv/repo/migrations/20230721133659_create_active_channels.exs
@@ -1,0 +1,16 @@
+defmodule NauticNet.Repo.Migrations.CreateActiveChannels do
+  use Ecto.Migration
+
+  def change do
+    up = """
+    CREATE MATERIALIZED VIEW active_channels AS
+      SELECT DISTINCT DATE(time) as utc_date, boat_id, sensor_id, type FROM samples
+    """
+
+    down = """
+    DROP MATERIALIZED VIEW active_channels
+    """
+
+    execute(up, down)
+  end
+end


### PR DESCRIPTION
Fixes #26 

- Create `active_signals` materialized view and refresh it every minute
- Leverage this in `Playback.list_channels_on/2`
- Create `%LocalDate{}` struct to encapsulate date + timezone