### PR TITLE
Clarify compass heading verbiage

### DIFF
--- a/lib/nautic_net/data/sample.ex
+++ b/lib/nautic_net/data/sample.ex
@@ -139,9 +139,6 @@ defmodule NauticNet.Data.Sample do
   def attrs_from_protobuf_sample(
         {_field, %Protobuf.TrackerSample{rover_data: %Protobuf.RoverData{} = rover_data} = sample}
       ) do
-    # TODO: Calculate magnetic declination based on lat/lon... currently hardcoded to Hingham, MA (14.21° W declination)
-    declination_deg = -14.21
-
     {:ok,
      [
        %{type: :rssi, magnitude: sample.rssi * 1.0},
@@ -153,13 +150,6 @@ defmodule NauticNet.Data.Sample do
        %{
          type: :magnetic_heading,
          angle: Protobuf.Convert.decode_unit(rover_data.heading, :ddeg, :rad)
-       },
-       %{
-         type: :true_heading,
-         angle:
-           rover_data.heading
-           |> Protobuf.Convert.decode_unit(:ddeg, :rad)
-           |> Math.add_radians(Math.deg2rad(declination_deg))
        },
        %{
          type: :heel,

--- a/lib/nautic_net/data/sample.ex
+++ b/lib/nautic_net/data/sample.ex
@@ -3,7 +3,6 @@ defmodule NauticNet.Data.Sample do
   use NauticNet.Schema
 
   alias NauticNet.Data.Sensor
-  alias NauticNet.Math
   alias NauticNet.Playback.Channel
   alias NauticNet.Protobuf
   alias NauticNet.Racing.Boat

--- a/lib/nautic_net/math.ex
+++ b/lib/nautic_net/math.ex
@@ -1,0 +1,32 @@
+defmodule NauticNet.Math do
+  @moduledoc """
+  Simple arithmetic.
+  """
+
+  @pi :math.pi()
+  @two_pi 2 * :math.pi()
+
+  @doc """
+  Adds two headings together in radians, wrapping around at 0.
+  """
+  def add_radians(rad1, rad2) do
+    :math.fmod(rad1 + rad2 + @two_pi, @two_pi)
+  end
+
+  @doc """
+  Adds two headings together in degrees, wrapping around at 0°.
+  """
+  def add_degrees(deg1, deg2) do
+    rad2deg(add_radians(deg2rad(deg1), deg2rad(deg2)))
+  end
+
+  @doc """
+  Converts degrees to radians.
+  """
+  def deg2rad(deg), do: deg * @pi / 180
+
+  @doc """
+  Converts radians to degrees.
+  """
+  def rad2deg(rad), do: rad * 180 / @pi
+end

--- a/lib/nautic_net/math.ex
+++ b/lib/nautic_net/math.ex
@@ -17,7 +17,7 @@ defmodule NauticNet.Math do
   Adds two headings together in degrees, wrapping around at 0°.
   """
   def add_degrees(deg1, deg2) do
-    rad2deg(add_radians(deg2rad(deg1), deg2rad(deg2)))
+    :math.fmod(deg1 + deg2 + 360, 360)
   end
 
   @doc """

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -31,6 +31,7 @@ defmodule NauticNetWeb.MapLive do
     %{type: :speed_through_water, label: "Speed Thru Water", field: :magnitude, unit: :kn},
     %{type: :velocity_over_ground, label: "SOG", field: :magnitude, unit: :kn},
     %{type: :apparent_wind, label: "Apparent Wind", field: :angle, unit: :deg},
+    %{type: :apparent_wind, label: "Apparent Wind", field: :magnitude, unit: :kn},
     %{type: :water_depth, label: "Depth", field: :magnitude, unit: :ft},
     %{type: :battery, label: "Battery", field: :magnitude, unit: :percent, precision: 0},
     %{type: :heel, label: "Heel", field: :angle, unit: :deg},

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -20,7 +20,13 @@ defmodule NauticNetWeb.MapLive do
   @timezone "America/New_York"
 
   @signal_views [
-    %{type: :true_heading, label: "True Heading", field: :angle, unit: :deg},
+    %{type: :true_heading, label: "Compass Heading (True)", field: :angle, unit: :deg_true},
+    %{
+      type: :magnetic_heading,
+      label: "Compass Heading (Magnetic)",
+      field: :angle,
+      unit: :deg_magnetic
+    },
     %{type: :velocity_over_ground, label: "COG", field: :angle, unit: :deg},
     %{type: :speed_through_water, label: "Speed Thru Water", field: :magnitude, unit: :kn},
     %{type: :velocity_over_ground, label: "SOG", field: :magnitude, unit: :kn},
@@ -28,7 +34,6 @@ defmodule NauticNetWeb.MapLive do
     %{type: :water_depth, label: "Depth", field: :magnitude, unit: :ft},
     %{type: :battery, label: "Battery", field: :magnitude, unit: :percent, precision: 0},
     %{type: :heel, label: "Heel", field: :angle, unit: :deg},
-    %{type: :magnetic_heading, label: "Magnetic Heading", field: :angle, unit: :deg},
     %{type: :rssi, label: "RSSI", field: :magnitude, unit: :dbm, precision: 0}
   ]
 
@@ -507,17 +512,20 @@ defmodule NauticNetWeb.MapLive do
   attr(:label, :string, required: true)
   attr(:signal, Signal, required: true)
   attr(:field, :atom, required: true, values: [:angle, :magnitude])
-  attr(:unit, :atom, required: true, values: [:deg, :kn, :ft])
+  attr(:unit, :atom, required: true, values: [:deg, :deg_magnetic, :deg_true, :kn, :ft])
   attr(:precision, :integer, required: false)
   attr(:show_sensor, :boolean, required: false, default: true)
 
   defp signal_view(assigns) do
     assigns =
       assign_new(assigns, :precision, fn ->
-        if assigns.unit == :deg, do: 0, else: 1
+        if assigns.unit in [:deg, :deg_magnetic, :deg_true], do: 0, else: 1
       end)
 
-    channel_unit = if assigns.unit == :deg, do: :rad, else: assigns.signal.channel.unit
+    channel_unit =
+      if assigns.unit in [:deg, :deg_magnetic, :deg_true],
+        do: :rad,
+        else: assigns.signal.channel.unit
 
     display_value =
       if assigns.signal.latest_sample do
@@ -552,12 +560,17 @@ defmodule NauticNetWeb.MapLive do
   defp unit(:percent), do: "%"
   defp unit(:dbm), do: "dBm"
   defp unit(:deg), do: "°"
+  defp unit(:deg_magnetic), do: "°M"
+  defp unit(:deg_true), do: "°T"
   defp unit(:kn), do: "kn"
   defp unit(:ft), do: "ft"
 
   defp convert(value, same, same), do: value * 1.0
   defp convert(value, :m_s, :kn), do: value * 1.94384
-  defp convert(value, :rad, :deg), do: value * 180 / :math.pi()
+
+  defp convert(value, :rad, deg) when deg in [:deg, :deg_magnetic, :deg_true],
+    do: value * 180 / :math.pi()
+
   defp convert(value, :m, :ft), do: value * 3.28084
 
   defp now_ms, do: System.monotonic_time(:millisecond)

--- a/test/nautic_net/math_test.exs
+++ b/test/nautic_net/math_test.exs
@@ -5,7 +5,7 @@ defmodule NauticNet.MathTest do
 
   @delta 0.001
 
-  describe "add_degress/2" do
+  describe "add_degrees/2" do
     test "works" do
       assert_in_delta Math.add_degrees(0, 0), 0, @delta
       assert_in_delta Math.add_degrees(0, 10), 10, @delta

--- a/test/nautic_net/math_test.exs
+++ b/test/nautic_net/math_test.exs
@@ -1,0 +1,41 @@
+defmodule NauticNet.MathTest do
+  use ExUnit.Case
+
+  alias NauticNet.Math
+
+  @delta 0.001
+
+  describe "add_degress/2" do
+    test "works" do
+      assert_in_delta Math.add_degrees(0, 0), 0, @delta
+      assert_in_delta Math.add_degrees(0, 10), 10, @delta
+      assert_in_delta Math.add_degrees(0, 200), 200, @delta
+      assert_in_delta Math.add_degrees(0, 360), 0, @delta
+      assert_in_delta Math.add_degrees(0, 370), 10, @delta
+      assert_in_delta Math.add_degrees(0, -10), 350, @delta
+      assert_in_delta Math.add_degrees(20, -40), 340, @delta
+      assert_in_delta Math.add_degrees(-10, -10), 340, @delta
+      assert_in_delta Math.add_degrees(350, 350), 340, @delta
+    end
+  end
+
+  describe "deg2rad/1" do
+    test "works" do
+      assert Math.deg2rad(0) == 0
+      assert Math.deg2rad(90) == 0.5 * :math.pi()
+      assert Math.deg2rad(180) == 1.0 * :math.pi()
+      assert Math.deg2rad(270) == 1.5 * :math.pi()
+      assert Math.deg2rad(360) == 2.0 * :math.pi()
+    end
+  end
+
+  describe "rad2deg/1" do
+    test "works" do
+      assert Math.rad2deg(0) == 0
+      assert Math.rad2deg(0.5 * :math.pi()) == 90
+      assert Math.rad2deg(1.0 * :math.pi()) == 180
+      assert Math.rad2deg(1.5 * :math.pi()) == 270
+      assert Math.rad2deg(2.0 * :math.pi()) == 360
+    end
+  end
+end


### PR DESCRIPTION
Fixes #30 

- Make magnetic and true headings more explicit
- Add apparent wind speed display
- Fix heading math (now with tests!)
- Don't create fudged `:true_heading` samples for mini tracker compass measurements