### PR TITLE
UI state deep linking

### DIFF
--- a/assets/js/rangeSlider.js
+++ b/assets/js/rangeSlider.js
@@ -2,18 +2,20 @@ import noUiSlider from "nouislider";
 
 export default {
   mounted() {
-    let { min, max } = this.el.dataset;
+    let { min, max, from, to } = this.el.dataset;
     min = parseInt(min);
+    from = parseInt(from);
     max = parseInt(max);
+    to = parseInt(to);
 
     noUiSlider.create(this.el, {
-      start: [min, max],
+      start: [from, to],
       connect: true,
       behaviour: "tap-drag",
       range: { min, max },
     });
 
-    this.el.noUiSlider.on("update", ([min, max], _handle) => {
+    this.el.noUiSlider.on("update", ([min, max], _handle) => {      
       this.pushEvent("update_range", { min, max });
     });
 

--- a/lib/nautic_net/playback/signal.ex
+++ b/lib/nautic_net/playback/signal.ex
@@ -10,7 +10,7 @@ defmodule NauticNet.Playback.Signal do
     latest_sample: nil,
 
     # If the signal is shown at all
-    visible?: true,
+    visible?: false,
 
     # Hex foreground color
     color: "#000000"

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -534,11 +534,11 @@ defmodule NauticNetWeb.MapLive do
     |> assign(:position, position)
     |> assign(:boats, selected_boats)
     |> constrain_inspect_at()
-    |> push_event("configure", %{
-      id: "range-slider",
-      min: DateTime.to_unix(first_sample_at),
-      max: DateTime.to_unix(last_sample_at)
-    })
+    # |> push_event("configure", %{
+    #   id: "range-slider",
+    #   min: DateTime.to_unix(first_sample_at),
+    #   max: DateTime.to_unix(last_sample_at)
+    # })
     |> push_boat_coordinates()
     |> push_map_state()
     |> select_boat(first_position_signal)

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -494,7 +494,6 @@ defmodule NauticNetWeb.MapLive do
     local_date = %LocalDate{date: date, timezone: @timezone}
     selected_boats = selected_boats(params["boats"])
 
-
     signals =
       local_date
       |> Playback.list_channels_on()

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -74,7 +74,7 @@ defmodule NauticNetWeb.MapLive do
       |> assign(date: params["date"])
       |> assign(from: params["from"])
       |> assign(to: params["to"])
-      |> assign(to: params["position"])
+      |> assign(position: params["position"])
 
     {:noreply, socket}
   end

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -40,7 +40,6 @@ defmodule NauticNetWeb.MapLive do
 
   def mount(params, _session, socket) do
     if connected?(socket), do: PubSub.subscribe(NauticNet.PubSub, "leaflet")
-    IO.inspect(params)
 
     socket =
       socket
@@ -64,7 +63,6 @@ defmodule NauticNetWeb.MapLive do
       |> assign(:zoom_level, 15)
 
       # Timeline
-      # |> assign(:inspect_at, DateTime.utc_now())
       |> select_date(params)
 
     {:ok, socket}

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -108,8 +108,8 @@ defmodule NauticNetWeb.MapLive do
     range_start_at = parse_unix_datetime(min, socket.assigns.local_date.timezone)
     range_end_at = parse_unix_datetime(max, socket.assigns.local_date.timezone)
 
-    from = "#{range_start_at.hour}:#{range_start_at.minute}:#{range_start_at.second}"
-    to = "#{range_end_at.hour}:#{range_end_at.minute}:#{range_end_at.second}"
+    from = range_start_at |> DateTime.to_time |> Time.to_string |> String.split(".") |> List.first
+    to = range_end_at |> DateTime.to_time |> Time.to_string |> String.split(".") |> List.first
 
     {:noreply,
      socket
@@ -352,7 +352,9 @@ defmodule NauticNetWeb.MapLive do
       first_sample_at: DateTime.to_unix(assigns.first_sample_at),
       last_sample_at: DateTime.to_unix(assigns.last_sample_at),
       range_start_at: DateTime.to_unix(assigns.range_start_at),
+      from: DateTime.to_unix(assigns.range_start_at),
       range_end_at: DateTime.to_unix(assigns.range_end_at),
+      to: DateTime.to_unix(assigns.range_end_at),
       inspect_at: DateTime.to_unix(assigns.inspect_at)
     })
   end

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -74,7 +74,7 @@ defmodule NauticNetWeb.MapLive do
       |> assign(date: params["date"])
       |> assign(from: params["from"])
       |> assign(to: params["to"])
-      |> assign(position: params["position"])
+      |> assign(playback: params["playback"])
       |> assign(boats: selected_boats(params["boats"]))
 
     {:noreply, socket}
@@ -113,7 +113,7 @@ defmodule NauticNetWeb.MapLive do
         date: socket.assigns.date,
         from: to_time(range_start_at),
         to: to_time(range_end_at),
-        position: to_time(socket.assigns.inspect_at),
+        playback: to_time(socket.assigns.inspect_at),
         boats: socket.assigns.boats
       }
       |> Plug.Conn.Query.encode()
@@ -151,7 +151,7 @@ defmodule NauticNetWeb.MapLive do
         date: socket.assigns.date,
         from: socket.assigns.from,
         to: socket.assigns.to,
-        position: socket.assigns.position,
+        playback: socket.assigns.playback,
         boats: new_boats
       }
       |> Plug.Conn.Query.encode()
@@ -384,7 +384,7 @@ defmodule NauticNetWeb.MapLive do
     # 10751 is the max value for position
 
     new_inspect_at =
-      if pos = params["position"] do
+      if pos = params["playback"] do
         parse_unix_datetime(pos, assigns.local_date.timezone)
       else
         assigns.inspect_at
@@ -395,7 +395,7 @@ defmodule NauticNetWeb.MapLive do
         date: socket.assigns.date,
         from: to_time(socket.assigns.range_start_at),
         to: to_time(socket.assigns.range_end_at),
-        position: to_time(new_inspect_at),
+        playback: to_time(new_inspect_at),
         boats: socket.assigns.boats
       }
       |> Plug.Conn.Query.encode()
@@ -514,7 +514,7 @@ defmodule NauticNetWeb.MapLive do
 
     range_start_at = build_datetime(params["date"], params["from"], first_sample_at)
     range_end_at = build_datetime(params["date"], params["to"], last_sample_at)
-    position = build_datetime(params["date"], params["position"], DateTime.utc_now())
+    playback = build_datetime(params["date"], params["playback"], DateTime.utc_now())
 
     first_position_signal = Enum.find(signals, &(&1.channel.type == :position))
 
@@ -530,8 +530,8 @@ defmodule NauticNetWeb.MapLive do
     |> assign(:from, range_start_at)
     |> assign(:range_end_at, range_end_at)
     |> assign(:to, range_end_at)
-    |> assign(:inspect_at, position)
-    |> assign(:position, position)
+    |> assign(:inspect_at, playback)
+    |> assign(:playback, playback)
     |> assign(:boats, selected_boats)
     |> constrain_inspect_at()
     # |> push_event("configure", %{

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -352,9 +352,7 @@ defmodule NauticNetWeb.MapLive do
       first_sample_at: DateTime.to_unix(assigns.first_sample_at),
       last_sample_at: DateTime.to_unix(assigns.last_sample_at),
       range_start_at: DateTime.to_unix(assigns.range_start_at),
-      from: DateTime.to_unix(assigns.range_start_at),
       range_end_at: DateTime.to_unix(assigns.range_end_at),
-      to: DateTime.to_unix(assigns.range_end_at),
       inspect_at: DateTime.to_unix(assigns.inspect_at)
     })
   end
@@ -379,7 +377,6 @@ defmodule NauticNetWeb.MapLive do
     socket
     |> assign(:signals, new_signals)
     |> assign(:inspect_at, new_inspect_at)
-    |> assign(:position, position)
     |> push_map_state()
     |> push_patch(
       to: "/?date=#{socket.assigns.date}&from=#{from}&to=#{to}&position=#{position}",
@@ -485,8 +482,6 @@ defmodule NauticNetWeb.MapLive do
     range_end_at = build_datetime(params["date"], params["to"], last_sample_at)
     position = build_datetime(params["date"], params["position"], DateTime.utc_now())
 
-    from = if params["from"], do: params["from"], else: "00:00:00"
-    to = if params["to"], do: params["to"], else: "23:59:59"
     first_position_signal = Enum.find(signals, &(&1.channel.type == :position))
 
     socket
@@ -498,9 +493,7 @@ defmodule NauticNetWeb.MapLive do
     |> assign(:first_sample_at, first_sample_at)
     |> assign(:last_sample_at, last_sample_at)
     |> assign(:range_start_at, range_start_at)
-    |> assign(:from, from)
     |> assign(:range_end_at, range_end_at)
-    |> assign(:to, to)
     |> assign(:inspect_at, position)
     |> constrain_inspect_at()
     |> push_event("configure", %{

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -108,8 +108,15 @@ defmodule NauticNetWeb.MapLive do
     range_start_at = parse_unix_datetime(min, socket.assigns.local_date.timezone)
     range_end_at = parse_unix_datetime(max, socket.assigns.local_date.timezone)
 
-    from = range_start_at |> DateTime.to_time |> Time.to_string |> String.split(".") |> List.first
-    to = range_end_at |> DateTime.to_time |> Time.to_string |> String.split(".") |> List.first
+    from =
+      range_start_at
+      |> DateTime.to_time()
+      |> Time.to_string()
+      |> String.split(".")
+      |> List.first()
+
+    to =
+      range_end_at |> DateTime.to_time() |> Time.to_string() |> String.split(".") |> List.first()
 
     {:noreply,
      socket
@@ -119,9 +126,10 @@ defmodule NauticNetWeb.MapLive do
      |> assign(:to, to)
      |> constrain_inspect_at()
      |> push_map_state()
-     |> push_patch(to: "/?date=#{socket.assigns.date || Timex.today(@timezone)}&from=#{from}&to=#{to}", replace: true)
-    }
-
+     |> push_patch(
+       to: "/?date=#{socket.assigns.date || Timex.today(@timezone)}&from=#{from}&to=#{to}",
+       replace: true
+     )}
   end
 
   def handle_event("set_boat_visible", %{"boat-id" => boat_id} = params, socket) do
@@ -471,6 +479,7 @@ defmodule NauticNetWeb.MapLive do
 
     # Set up the range for the main slider
     {first_sample_at, last_sample_at} = Playback.get_sample_range_on(local_date)
+
     range_start_at =
       if params["date"] && params["from"] do
         "#{params["date"]}T#{params["from"]}"

--- a/lib/nautic_net_web/live/map_live.html.heex
+++ b/lib/nautic_net_web/live/map_live.html.heex
@@ -38,7 +38,9 @@
     phx-hook="RangeSliderHook"
     phx-update="ignore"
     data-min={DateTime.to_unix(@first_sample_at)}
+    data-from={DateTime.to_unix(@range_start_at)}
     data-max={DateTime.to_unix(@last_sample_at)}
+    data-to={DateTime.to_unix(@range_end_at)}
   />
   <div class="flex justify-between mt-2">
     <div>From <%= format_time(@range_start_at) %></div>


### PR DESCRIPTION
Closes #35 

- [x] Link `date`
- [x] Link range scrubber start as `from`
- [x] Link range scrubber stop as `to`
- [x] Link current playback position as `position`
- [x] No boats should be pre-selected
- [x] Boats selected - when selecting boats to visualize this collection should be represented in the URL
- [x]  Fix the scrubber state (from, to) on page load