### PR TITLE
Add time fields for playback and range sliders

### DIFF
--- a/assets/js/rangeSlider.js
+++ b/assets/js/rangeSlider.js
@@ -27,6 +27,11 @@ export default {
       }
     });
 
+    this.handleEvent("configure_date", ({ min, max }) => {
+      this.el.noUiSlider.updateOptions({ range: { min, max } });
+      this.el.noUiSlider.set([min, max]);
+    });
+
     this.handleEvent("configure", ({ min, max }) => {
       // this.el.noUiSlider.updateOptions({ range: { min, max } });
       this.el.noUiSlider.set([min, max]);

--- a/assets/js/rangeSlider.js
+++ b/assets/js/rangeSlider.js
@@ -28,7 +28,7 @@ export default {
     });
 
     this.handleEvent("configure", ({ min, max }) => {
-      this.el.noUiSlider.updateOptions({ range: { min, max } });
+      // this.el.noUiSlider.updateOptions({ range: { min, max } });
       this.el.noUiSlider.set([min, max]);
       // this.el.noUiSlider.reset();
     });

--- a/assets/js/rangeSlider.js
+++ b/assets/js/rangeSlider.js
@@ -15,7 +15,7 @@ export default {
       range: { min, max },
     });
 
-    this.el.noUiSlider.on("update", ([min, max], _handle) => {      
+    this.el.noUiSlider.on("update", ([min, max], _handle) => {
       this.pushEvent("update_range", { min, max });
     });
 
@@ -30,6 +30,7 @@ export default {
     this.handleEvent("configure", ({ min, max }) => {
       this.el.noUiSlider.updateOptions({ range: { min, max } });
       this.el.noUiSlider.set([min, max]);
+      this.el.noUiSlider.reset();
     });
   },
 };

--- a/assets/js/rangeSlider.js
+++ b/assets/js/rangeSlider.js
@@ -30,7 +30,7 @@ export default {
     this.handleEvent("configure", ({ min, max }) => {
       this.el.noUiSlider.updateOptions({ range: { min, max } });
       this.el.noUiSlider.set([min, max]);
-      this.el.noUiSlider.reset();
+      // this.el.noUiSlider.reset();
     });
   },
 };

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -191,11 +191,11 @@ defmodule NauticNetWeb.MapLive do
       |> assign(:range_end_at, range_end_at)
       |> assign(:from, from)
       |> assign(:to, to)
-      # |> push_event("configure", %{
-      #   id: "range-slider",
-      #   min: DateTime.to_unix(range_start_at),
-      #   max: DateTime.to_unix(range_end_at)
-      # })
+      |> push_event("configure", %{
+        id: "range-slider",
+        min: DateTime.to_unix(range_start_at),
+        max: DateTime.to_unix(range_end_at)
+      })
       |> push_patch(to: "/?#{query_params}", replace: true)
 
     {:noreply, socket}
@@ -695,11 +695,11 @@ defmodule NauticNetWeb.MapLive do
     |> assign(:playback_speed, speed)
     |> assign(:boats, selected_boats)
     |> constrain_inspect_at()
-    # |> push_event("configure", %{
-    #   id: "range-slider",
-    #   min: DateTime.to_unix(first_sample_at),
-    #   max: DateTime.to_unix(last_sample_at)
-    # })
+    |> push_event("configure", %{
+      id: "range-slider",
+      min: DateTime.to_unix(first_sample_at),
+      max: DateTime.to_unix(last_sample_at)
+    })
     |> push_boat_coordinates()
     |> push_map_state()
     |> select_boat(first_position_signal)

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -711,11 +711,11 @@ defmodule NauticNetWeb.MapLive do
     |> assign(:playback_speed, speed)
     |> assign(:boats, selected_boats)
     |> constrain_inspect_at()
-    |> push_event("configure", %{
-      id: "range-slider",
-      min: DateTime.to_unix(first_sample_at),
-      max: DateTime.to_unix(last_sample_at)
-    })
+    # |> push_event("configure", %{
+    #   id: "range-slider",
+    #   min: DateTime.to_unix(first_sample_at),
+    #   max: DateTime.to_unix(last_sample_at)
+    # })
     |> push_boat_coordinates()
     |> push_map_state()
     |> select_boat(first_position_signal)

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -1008,7 +1008,7 @@ defmodule NauticNetWeb.MapLive do
     |> length()
   end
 
-  defp format_time(datetime) do
-    Timex.format!(datetime, "{h12}:{m}:{s}{am} {Zabbr}")
-  end
+  # defp format_time(datetime) do
+  #   Timex.format!(datetime, "{h12}:{m}:{s}{am} {Zabbr}")
+  # end
 end

--- a/lib/nautic_net_web/live/map_live.ex
+++ b/lib/nautic_net_web/live/map_live.ex
@@ -168,47 +168,8 @@ defmodule NauticNetWeb.MapLive do
   end
 
   def handle_event("update_from_to", %{"from" => from, "to" => to}, %{assigns: assigns} = socket) do
-    first_sample_time = to_time(assigns.first_sample_at) |> Time.from_iso8601!()
-    last_sample_time = to_time(assigns.last_sample_at) |> Time.from_iso8601!()
-
-    from2 =
-      case Time.from_iso8601(from) do
-        {:ok, from} -> from
-        _ -> first_sample_time
-      end
-
-    from =
-      case Time.compare(from2, first_sample_time) do
-        :lt ->
-          Time.to_string(first_sample_time)
-
-        _ ->
-          case Time.compare(from2, last_sample_time) do
-            :gt -> Time.to_string(last_sample_time)
-            _ -> from
-          end
-      end
-
-    to2 =
-      case Time.from_iso8601(to) do
-        {:ok, to} -> to
-        _ -> last_sample_time
-      end
-
-    to =
-      case Time.compare(to2, last_sample_time) do
-        :gt ->
-          Time.to_string(last_sample_time)
-
-        _ ->
-          case Time.compare(to2, first_sample_time) do
-            :lt ->
-              Time.to_string(first_sample_time)
-
-            _ ->
-              to
-          end
-      end
+    from = validate_from(assigns, from)
+    to = validate_to(assigns, to)
 
     range_start_at = build_datetime(assigns.date, from, assigns.first_sample_at)
     range_end_at = build_datetime(assigns.date, to, assigns.last_sample_at)
@@ -1011,4 +972,51 @@ defmodule NauticNetWeb.MapLive do
   # defp format_time(datetime) do
   #   Timex.format!(datetime, "{h12}:{m}:{s}{am} {Zabbr}")
   # end
+
+  defp validate_from(assigns, from) do
+    first_sample_time = to_time(assigns.first_sample_at) |> Time.from_iso8601!()
+    last_sample_time = to_time(assigns.last_sample_at) |> Time.from_iso8601!()
+
+    from2 =
+      case Time.from_iso8601(from) do
+        {:ok, from} -> from
+        _ -> first_sample_time
+      end
+
+    case Time.compare(from2, first_sample_time) do
+      :lt ->
+        Time.to_string(first_sample_time)
+
+      _ ->
+        case Time.compare(from2, last_sample_time) do
+          :gt -> Time.to_string(last_sample_time)
+          _ -> from
+        end
+    end
+  end
+
+  defp validate_to(assigns, to) do
+    first_sample_time = to_time(assigns.first_sample_at) |> Time.from_iso8601!()
+    last_sample_time = to_time(assigns.last_sample_at) |> Time.from_iso8601!()
+
+    to2 =
+      case Time.from_iso8601(to) do
+        {:ok, to} -> to
+        _ -> last_sample_time
+      end
+
+    case Time.compare(to2, last_sample_time) do
+      :gt ->
+        Time.to_string(last_sample_time)
+
+      _ ->
+        case Time.compare(to2, first_sample_time) do
+          :lt ->
+            Time.to_string(first_sample_time)
+
+          _ ->
+            to
+        end
+    end
+  end
 end

--- a/lib/nautic_net_web/live/map_live.html.heex
+++ b/lib/nautic_net_web/live/map_live.html.heex
@@ -38,8 +38,8 @@
     phx-hook="RangeSliderHook"
     phx-update="ignore"
     data-min={DateTime.to_unix(@first_sample_at)}
-    data-from={DateTime.to_unix(@range_start_at)}
     data-max={DateTime.to_unix(@last_sample_at)}
+    data-from={DateTime.to_unix(@range_start_at)}
     data-to={DateTime.to_unix(@range_end_at)}
   />
 </div>

--- a/lib/nautic_net_web/live/map_live.html.heex
+++ b/lib/nautic_net_web/live/map_live.html.heex
@@ -32,6 +32,16 @@
   </div>
 </div>
 
+<form phx-change="update_from_to">
+  <div class="flex justify-between mt-4">
+    <div>
+      <.input type="time" id="from" errors={[]} name="from" value={@from} />
+    </div>
+    <div>
+      <.input type="time" id="to" errors={[]} name="to" value={@to} />
+    </div>
+  </div>
+</form>
 <div class="my-6 px-4">
   <div
     id="range-slider"
@@ -48,11 +58,18 @@
   </div>
 </div>
 
+<form phx-change="update_playback">
+  <div class="flex justify-between mt-4">
+    <div>
+      <.input type="time" id="playback" errors={[]} name="playback" value={@playback} />
+    </div>
+  </div>
+</form>
 <form
   phx-change={Phoenix.LiveView.JS.dispatch("handleSetPosition")}
   phx-click={Phoenix.LiveView.JS.dispatch("handleSetPosition")}
   phx-throttle="500"
-  class="mt-4"
+  class="mt-2"
 >
   <input
     style="width:100%"

--- a/lib/nautic_net_web/live/map_live.html.heex
+++ b/lib/nautic_net_web/live/map_live.html.heex
@@ -32,17 +32,7 @@
   </div>
 </div>
 
-<form phx-change="update_from_to">
-  <div class="flex justify-between mt-4">
-    <div>
-      <.input type="time" id="from" errors={[]} name="from" value={@from} />
-    </div>
-    <div>
-      <.input type="time" id="to" errors={[]} name="to" value={@to} />
-    </div>
-  </div>
-</form>
-<div class="my-6 px-4">
+<div class="px-4 mt-6">
   <div
     id="range-slider"
     phx-hook="RangeSliderHook"
@@ -52,19 +42,18 @@
     data-max={DateTime.to_unix(@last_sample_at)}
     data-to={DateTime.to_unix(@range_end_at)}
   />
-  <div class="flex justify-between mt-2">
-    <div>From <%= format_time(@range_start_at) %></div>
-    <div>To <%= format_time(@range_end_at) %></div>
-  </div>
 </div>
-
-<form phx-change="update_playback">
-  <div class="flex justify-between mt-4">
+<form phx-change="update_from_to">
+  <div class="flex justify-between mt-2 mb-6">
     <div>
-      <.input type="time" id="playback" errors={[]} name="playback" value={@playback} />
+      <.input type="text" id="from" errors={[]} name="from" value={@from} phx-debounce="1000" />
+    </div>
+    <div>
+      <.input type="text" id="to" errors={[]} name="to" value={@to} phx-debounce="1000" />
     </div>
   </div>
 </form>
+
 <form
   phx-change={Phoenix.LiveView.JS.dispatch("handleSetPosition")}
   phx-click={Phoenix.LiveView.JS.dispatch("handleSetPosition")}
@@ -83,7 +72,20 @@
   />
 </form>
 
-<div>Inspect <%= format_time(@inspect_at) %></div>
+<form phx-change="update_playback">
+  <div class="flex justify-between mb-4">
+    <div>
+      <.input
+        type="text"
+        id="playback"
+        errors={[]}
+        name="playback"
+        value={@playback}
+        phx-debounce="1000"
+      />
+    </div>
+  </div>
+</form>
 
 <div class="my-4">
   <.button


### PR DESCRIPTION
Closes #50 

**Screenshot**
![2023-08-17 21 54 41](https://github.com/opensailing/nautic_net_web/assets/419670/bfc54ec2-d34b-47ef-a28f-ed6e5fcb4574)

**Issue**
- [x] When we change the date then range sliders start positions are incorrect although we can grab them and change their positions but I think its a bug and we need to fix it.
![2023-08-17 21 59 19](https://github.com/opensailing/nautic_net_web/assets/419670/24f9b076-7c32-41b3-a761-947eee005f95)


**Final Screenshot**
![2023-08-18 21 34 43](https://github.com/opensailing/nautic_net_web/assets/419670/00efb5d0-2cf0-4e8f-b4bd-30e4438eb391)
